### PR TITLE
Use HTTPS for page resources, including broken html5shiv resource.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,13 +25,13 @@
     <link rel="stylesheet" href="stylesheets/htmlize.css">
 	<link rel="stylesheet" href="stylesheets/lein.css">
 
-    <link href="http://fonts.googleapis.com/css?family=Inconsolata"
+    <link href="https://fonts.googleapis.com/css?family=Inconsolata"
           rel="stylesheet" type="text/css">	
-    <link href="http://fonts.googleapis.com/css?family=Bitter"
+    <link href="https://fonts.googleapis.com/css?family=Bitter"
           rel="stylesheet" type="text/css">
 
     <!--[if lt IE 9]>
-		<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+		<script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
 	<![endif]-->
 
     <!-- TODO: bump text size? make body narrower? new header face? -->


### PR DESCRIPTION
Google Code is dead; should probably just vendor that html5shiv file (only used in IE9). But this takes it from 404 -> 404 over secure channel. :-)

This is to partially address https://github.com/technomancy/leiningen.org/issues/9