### PR TITLE
Use HTTPS links where possible

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -67,13 +67,13 @@
 
     <div class="one-third column">
       <p id="pitch">Leiningen is <strong>the easiest way to use
-      <a href="http://clojure.org">Clojure</a></strong>. With a focus
+      <a href="https://clojure.org">Clojure</a></strong>. With a focus
       on project automation and declarative configuration, it gets out
       of your way and lets you focus on your code.</p>
     </div>
     <div class="two-thirds column">
     <pre class="htmlize" id="sample-project"><span class="esk-paren">(</span>defproject leiningen.org <span class="string">"1.0.0"</span>
-  <span class="constant">:description</span> <span class="string">"Generate static HTML for http://leiningen.org"</span>
+  <span class="constant">:description</span> <span class="string">"Generate static HTML for https://leiningen.org"</span>
   <span class="constant">:dependencies</span> [[enlive <span class="string">"1.0.1"</span>]
                  [cheshire <span class="string">"4.0.0"</span>]
                  [org.markdownj/markdownj <span class="string">"0.3.0-1.0.2b4"</span>]]
@@ -145,7 +145,7 @@
 
       <p>Discussion occurs primarily <a href="irc://chat.freenode.net#leiningen">in
         the #leiningen channel on Freenode</a>, but there is also a
-        <a href="http://www.freelists.org/list/leiningen">mailing
+        <a href="https://www.freelists.org/list/leiningen">mailing
         list</a>. To join the mailing list, email
         <a href="mailto:leiningen-request@freelists.org?subject=subscribe">leiningen-request@freelists.org</a>
         with 'subscribe' in the Subject field, then follow the


### PR DESCRIPTION
Lightly dependent on https://github.com/technomancy/leiningen.org/pull/10 for mention of HTTPS side of leiningen.org, which still has mixed content errors.